### PR TITLE
Add .doc support module

### DIFF
--- a/agentic_rag/__init__.py
+++ b/agentic_rag/__init__.py
@@ -1,0 +1,5 @@
+"""AgenticRAG package."""
+
+from .doc_handler import doc_to_text
+
+__all__ = ["doc_to_text"]

--- a/agentic_rag/doc_handler.py
+++ b/agentic_rag/doc_handler.py
@@ -1,0 +1,37 @@
+"""Utility functions to handle .doc format documents."""
+
+import os
+from typing import Optional
+
+try:
+    import textract  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    textract = None
+
+
+def doc_to_text(path: str) -> str:
+    """Return the extracted text from a .doc file.
+
+    Parameters
+    ----------
+    path: str
+        Path to the .doc file.
+
+    Raises
+    ------
+    ImportError
+        If the optional ``textract`` dependency is not installed.
+    FileNotFoundError
+        If the file does not exist.
+    """
+    if textract is None:
+        raise ImportError(
+            "textract is required to read .doc files. Install it with 'pip install textract'."
+        )
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+    text_bytes = textract.process(path)
+    return text_bytes.decode("utf-8")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ faiss-cpu
 langchain-text-splitters
 python-dotenv
 beautifulsoup4
+textract==1.6.3

--- a/tests/test_doc_handler.py
+++ b/tests/test_doc_handler.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agentic_rag import doc_to_text
+import pytest
+
+
+def test_doc_to_text_missing_file():
+    with pytest.raises(FileNotFoundError):
+        doc_to_text('nonexistent.doc')
+
+
+def test_doc_to_text_requires_textract(monkeypatch, tmp_path):
+    # simulate missing textract
+    monkeypatch.setitem(sys.modules, 'textract', None)
+    monkeypatch.setattr('agentic_rag.doc_handler.textract', None, raising=False)
+    test_file = tmp_path / 'empty.doc'
+    test_file.write_bytes(b'')
+    with pytest.raises(ImportError):
+        doc_to_text(str(test_file))


### PR DESCRIPTION
## Summary
- add `doc_handler` module for reading `.doc` files using `textract`
- expose `doc_to_text` in the package
- include dependency on `textract`
- test expected errors when file is missing or optional dependency not installed

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c65b38648333bc0b86514cc178e9